### PR TITLE
Fix spacing DiagnosticsProperty type

### DIFF
--- a/lib/render_signed_spacing_flex.dart
+++ b/lib/render_signed_spacing_flex.dart
@@ -1031,7 +1031,7 @@ class RenderSignedSpacingFlex extends RenderBox
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(EnumProperty<Axis>('direction', direction));
-    properties.add(EnumProperty<double>('spacing', spacing));
+    properties.add(DoubleProperty('spacing', spacing));
     properties.add(EnumProperty<MainAxisAlignment>(
         'mainAxisAlignment', mainAxisAlignment));
     properties.add(EnumProperty<MainAxisSize>('mainAxisSize', mainAxisSize));

--- a/lib/signed_spacing_flex.dart
+++ b/lib/signed_spacing_flex.dart
@@ -300,7 +300,7 @@ class SignedSpacingFlex extends MultiChildRenderObjectWidget {
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
     properties.add(EnumProperty<Axis>('direction', direction));
-    properties.add(EnumProperty<double>('spacing', spacing));
+    properties.add(DoubleProperty('spacing', spacing));
     properties.add(EnumProperty<StackingOrder>('stackingOrder', stackingOrder));
     properties.add(EnumProperty<MainAxisAlignment>(
         'mainAxisAlignment', mainAxisAlignment));


### PR DESCRIPTION
Fix `spacing` `DiagnosticsProperty` type from `EnumProperty<double>` to `DoubleProperty`, as of Flutter stable 3.16.0